### PR TITLE
Updated example to ignore multiple pubs

### DIFF
--- a/VideoData/ExampleCode/src/VideoPublisher/VideoPublisher.cxx
+++ b/VideoData/ExampleCode/src/VideoPublisher/VideoPublisher.cxx
@@ -44,6 +44,9 @@ public:
 	// --- Constructor ---
 	FrameHandler() : _seqNum(0)
 	{
+		srand(time(NULL));
+		_streamId = rand();
+		printf("Created frame publisher with unique stream ID: %d\n", _streamId);
 	}
 
 	// ------------------------------------------------------------------------
@@ -79,7 +82,7 @@ public:
 		}
 
 		streamData->flags = buffer->GetFlags();
-		streamData->stream_id = 234;
+		streamData->stream_id = _streamId;
 	
 		// Sending the data over the network (or shared memory)
 		pubInterface->Write(*streamData);
@@ -96,6 +99,8 @@ private:
 
 	// --- Private members --- 
 	int _seqNum;
+
+	int _streamId;
 
 };
 

--- a/VideoData/ExampleCode/src/VideoSubscriber/VideoSubscriber.cxx
+++ b/VideoData/ExampleCode/src/VideoSubscriber/VideoSubscriber.cxx
@@ -41,12 +41,26 @@ class VideoDisplayHandler : public VideoEventHandler
 {
 public:
 	VideoDisplayHandler(EMDSVideoOutput *outputHandler, bool *finishRun)
-			: _outputHandler(outputHandler), _finish(finishRun)
+			: _outputHandler(outputHandler), _finish(finishRun),
+			_streamId(-1)
 	{
 	}
 
-	virtual void OnFrameUpdate(EMDSBuffer *buffer)
+	virtual void OnFrameUpdate(EMDSBuffer *buffer, long streamId)
 	{
+		// The first time we get a stream, set the value of the 
+		// stream ID
+		if (_streamId == -1)
+		{
+			_streamId = streamId;
+		}
+
+		// This example can handle only one video stream at a time.  If we see
+		// a stream ID other than the one we are processing, don't process it.
+		if (_streamId != streamId)
+		{
+			return;
+		}
 		_outputHandler->GetFrameHandler()->FrameReady(_outputHandler, buffer);
 	}
 
@@ -59,6 +73,8 @@ private:
 
 	// --- Private members --- 
 	EMDSVideoOutput *_outputHandler;
+
+	long _streamId;
 
 	bool *_finish;
 };

--- a/VideoData/ExampleCode/src/VideoSubscriber/VideoSubscriberInterface.cxx
+++ b/VideoData/ExampleCode/src/VideoSubscriber/VideoSubscriberInterface.cxx
@@ -188,7 +188,9 @@ void VideoStreamListener::on_data_available(DataReader *reader)
 
 				double timestamp = infoSeq[i].source_timestamp.sec + 
 						(infoSeq[i].source_timestamp.nanosec / NANOSEC_TO_SEC);
-				_reader->NotifyHandlers(&dataSeq[i], timestamp);
+
+				_reader->NotifyHandlers(&dataSeq[i], dataSeq[i].stream_id, 
+					timestamp);
 			}
 		}
 
@@ -312,7 +314,8 @@ void VideoStreamReader::UnregisterVideoHandler(VideoEventHandler *handler)
 //
 // Notify handlers of frame events that a frame has arrived
 // 
-void VideoStreamReader::NotifyHandlers(VideoStream *frame, double timestamp)
+void VideoStreamReader::NotifyHandlers(VideoStream *frame, 
+	long streamId, double timestamp)
 {
 	EMDSBuffer *buffer = NULL;
 
@@ -331,7 +334,7 @@ void VideoStreamReader::NotifyHandlers(VideoStream *frame, double timestamp)
 
 		// If this is not the video end, notify the handler that a new
 		// frame update should be processed 
-		(*it)->OnFrameUpdate(buffer);
+		(*it)->OnFrameUpdate(buffer, streamId);
 	}
 }
 

--- a/VideoData/ExampleCode/src/VideoSubscriber/VideoSubscriberInterface.h
+++ b/VideoData/ExampleCode/src/VideoSubscriber/VideoSubscriberInterface.h
@@ -59,7 +59,7 @@ class VideoSubscriberInterface;
 class VideoEventHandler
 {
 public:
-	virtual void OnFrameUpdate(EMDSBuffer *buffer) = 0;
+	virtual void OnFrameUpdate(EMDSBuffer *buffer, long streamId) = 0;
 	virtual void OnVideoEnd() = 0;
 
 };
@@ -190,7 +190,7 @@ public:
 	void RegisterVideoHandler(VideoEventHandler *handler);
 	void UnregisterVideoHandler(VideoEventHandler *handler);
 	void NotifyHandlers(com::rti::media::generated::VideoStream *frame,
-				double timestamp);
+				long streamId, double timestamp);
 
 
 private:


### PR DESCRIPTION
This example can handle only a single video stream.  Updated the source
to:
1. Send a (theoretically) unique video stream ID
2. Not try to display video streams other than the first stream ID
received.
